### PR TITLE
Match BPM distribution of power laws

### DIFF
--- a/common/laws/BPM_distribution_of_power.txt
+++ b/common/laws/BPM_distribution_of_power.txt
@@ -35,7 +35,9 @@ law_autocracy = {
 		country_legitimacy_govt_size_add = 2
 		country_bureaucrats_pol_str_mult = 0.5
 		country_peasants_pol_str_mult = -0.4
-		
+		state_pop_pol_str_mult = -0.95
+		state_political_strength_from_wealth_mult = 1
+		state_pop_pol_str_add = -6
 		country_authority_add = 200
 		# country_bpm_base_mandate_add = 60
 	}
@@ -125,6 +127,7 @@ law_colonial_admin = {
 		country_liberty_desire_increase_mult = -0.5
 		country_liberty_desire_add = -0.1
 		country_authority_add = 200
+		#state_pop_pol_str_add = -5
 		country_bpm_change_primary_culture_to_overlord = yes
 		# country_bpm_base_mandate_add = 60
 	}
@@ -136,90 +139,15 @@ law_colonial_admin = {
 		country_legitimacy_govt_total_clout_add = -5
 		country_voting_power_wealth_threshold_add = -3
 		country_authority_add = -10
-		state_radicals_from_sol_change_mult = -0.025
+		state_radicals_from_political_movements_mult = -0.025
 	}
 
-	ai_enact_weight_modifier = { #Petitions
-		value = 0
-		
-		if = {
-			limit = { ai_has_enact_weight_modifier_journal_entries = yes }
-			add = 750
-		}
-	}
-}
-
-law_wealth_voting = {
-	group = lawgroup_distribution_of_power
-	
-	icon = "gfx/interface/icons/law_icons/wealth_voting.dds"
-	
-	progressiveness = 0
-
-	unlocking_technologies = {
-		democracy
-	}
-
-	disallowing_laws = {
-		law_chiefdom
-		law_command_economy
-	}
-	
-	modifier = {
-		country_legitimacy_govt_total_votes_add = 65
-		country_legitimacy_govt_total_clout_add = 75
-		country_legitimacy_govt_size_add = 1
-		
-		country_voting_power_base_add = 40
-		country_voting_power_wealth_threshold_add = 25
-		# country_bpm_base_mandate_add = 60
-		country_authority_add = 100
-	}
-
-	on_activate = {
-		scripted_effect_parties_emergence = yes
-		clear_legal_single_party = yes
-		if = {
-			limit = { has_modifier = bpm_republic_gov_size }
-			remove_modifier = bpm_republic_gov_size
-		}
-	}
-	
 	can_impose = {
-		country_has_voting_franchise = yes # modification of the standard trigger, only countries with a voting franchise can impose democracy on others
-		OR = {
-			AND = {
-				is_in_same_power_bloc = scope:target_country
-				AND = {
-					modifier:country_can_impose_same_lawgroup_distribution_of_power_in_power_bloc_bool = yes
-					has_law = scope:law
-				}
-			}
-			can_impose_law_default = yes
-		}
-	}
-	
-	pop_support = {
-		value = 0
-
-		add = {
-			desc = "POP_LITERACY"
-			
-			if = {
-				limit = { 
-					NOT = { strata = upper }
-					owner = { 
-						NOR = {
-							has_law = law_type:law_census_voting
-							has_law = law_type:law_universal_suffrage
-							has_law = law_type:law_anarchy
-						}	
-					}
-				}
-				add = {
-					value = literacy_rate
-					divide = 2
-				}
+		scope:target_country = {
+			is_subject_of = root
+			OR = {
+				is_subject_type = subject_type_chartered_company
+				is_subject_type = subject_type_colony
 			}
 		}
 	}
@@ -232,25 +160,6 @@ law_wealth_voting = {
 			add = 750
 		}
 	}
-	
-	ai_impose_chance = {
-		value = 0
-		
-		if = {
-			limit = {
-				has_law = law_type:law_wealth_voting
-				has_strategy = ai_strategy_progressive_agenda	
-				scope:target_country = { # Is their law different enough from what we want to impose?
-					NOR = { 
-						has_law = law_type:law_census_voting 
-						has_law = law_type:law_landed_voting 
-					}
-				}
-			}
-			
-			add = base_impose_law_weight
-		}
-	}	
 }
 
 law_military_junta = {
@@ -289,6 +198,8 @@ law_military_junta = {
 		country_officers_pol_str_mult = 1.25
 		country_aristocrats_pol_str_mult = 0.4
 		country_soldiers_pol_str_mult = 0.25
+		state_pop_pol_str_add = -4
+
 		country_authority_add = 100
 		# country_bpm_base_mandate_add = 60
 	}
@@ -307,7 +218,7 @@ law_military_junta = {
 	}
 
 	ai_will_do = {
-		ig:ig_armed_forces = { is_marginal = no }
+		ig:ig_armed_forces = { bpm_ig_is_marginal = no }
 		OR = {
 			ig:ig_armed_forces = { is_powerful = yes }
 			radical_fraction = {
@@ -366,6 +277,8 @@ law_oligarchy = {
 		country_capitalists_pol_str_mult = 0.40
 		country_officers_pol_str_mult = 0.40
 		country_authority_add = 100
+		state_pop_pol_str_add = -5
+
 		# country_bpm_base_mandate_add = 60
 	}
 
@@ -391,21 +304,21 @@ law_oligarchy = {
 		}
 	}
 
-	pop_support = {
-		value = 0
-		add = {
-			desc = "POP_OFFICERS"			
-			if = {
-				limit = {
-					owner = {
-						NOT = { has_law = law_type:law_wealth_voting }
-					}
-					is_pop_type = officers
-				}
-				value = 0.25
-			}
-		}
-	}
+#	pop_support = {
+#		value = 0
+#		add = {
+#			desc = "POP_OFFICERS"			
+#			if = {
+#				limit = {
+#					owner = {
+#						NOT = { has_law = law_type:law_wealth_voting }
+#					}
+#					is_pop_type = officers
+#				}
+#				value = 0.25
+#			}
+#		}
+#	}
 
 	ai_impose_chance = {
 		value = 0
@@ -482,7 +395,7 @@ law_technocracy = {
 			activate_law = law_type:law_appointed_bureaucrats
 		}
 		scripted_effect_parties_disappearence = yes
-		clear_legal_single_party = yes
+		#clear_legal_single_party = yes
 		if = {
 			limit = {
 				has_modifier = missouri_compromise
@@ -507,6 +420,9 @@ law_technocracy = {
 		country_academics_pol_str_mult = 0.33
 		country_engineers_pol_str_mult = 0.33
 		country_officers_pol_str_mult = 0.33
+		state_pop_pol_str_add = -3
+
+
 		# country_bpm_base_mandate_add = 50
 		country_authority_add = 100
 	}
@@ -528,30 +444,30 @@ law_technocracy = {
 		}
 	}
 	
-	pop_support = {
-		value = 0
-		add = {
-			desc = "POP_ACADEMICS"			
-			if = {
-				limit = {
-					is_pop_type = academics
-				}
-				value = 0.25
-			}
-		}
-		add = {
-			desc = "POP_CAPITALISTS"			
-			if = {
-				limit = {
-					owner = {
-						NOT = { has_law = law_type:law_wealth_voting }
-					}
-					is_pop_type = capitalists
-				}
-				value = 0.25
-			}
-		}
-	}
+#	pop_support = {
+#		value = 0
+#		add = {
+#			desc = "POP_ACADEMICS"			
+#			if = {
+#				limit = {
+#					is_pop_type = academics
+#				}
+#				value = 0.25
+#			}
+#		}
+#		add = {
+#			desc = "POP_CAPITALISTS"			
+#			if = {
+#				limit = {
+#					owner = {
+#						NOT = { has_law = law_type:law_wealth_voting }
+#					}
+#					is_pop_type = capitalists
+#				}
+#				value = 0.25
+#			}
+#		}
+#	}
 
 	ai_enact_weight_modifier = { #Petitions
 		value = 0
@@ -612,6 +528,8 @@ law_landed_voting = {
 		country_officers_voting_power_add = 5
 		country_clergymen_voting_power_add = 5
 		country_rigidity_baseline_add = -5
+		state_pop_pol_str_add = -3
+		state_political_strength_from_wealth_mult = 1
 	}
 
 	on_activate = {
@@ -640,34 +558,34 @@ law_landed_voting = {
 		}
 	}
 
-	pop_support = {
-		value = 0
-
-		add = {
-			desc = "POP_LITERACY" 
-			
-			if = {
-				limit = { 
-					OR = {
-						NOT = { strata = upper }
-						wealth < 30
-					}					
-					owner = { 
-						NOR = {
-							has_law = law_type:law_wealth_voting
-							has_law = law_type:law_census_voting
-							has_law = law_type:law_universal_suffrage
-							has_law = law_type:law_anarchy
-						}	
-					}
-				}
-				add = {
-					value = literacy_rate
-					divide = 2
-				}
-			}
-		}			
-	}
+#	pop_support = {
+#		value = 0
+#
+#		add = {
+#			desc = "POP_LITERACY" 
+#			
+#			if = {
+#				limit = { 
+#					OR = {
+#						NOT = { strata = upper }
+#						wealth < 30
+#					}					
+#					owner = { 
+#						NOR = {
+#							has_law = law_type:law_wealth_voting
+#							has_law = law_type:law_census_voting
+#							has_law = law_type:law_universal_suffrage
+#							has_law = law_type:law_anarchy
+#						}	
+#					}
+#				}
+#				add = {
+#					value = literacy_rate
+#					divide = 2
+#				}
+#			}
+#		}			
+#	}
 
 	ai_enact_weight_modifier = { #Petitions
 		value = 0
@@ -727,6 +645,9 @@ law_wealth_voting = {
 		country_voting_power_base_add = 10
 		country_authority_add = 100
 		country_institution_cost_institution_suffrage_mult = -0.85
+		state_pop_pol_str_add = -3
+		state_political_strength_from_wealth_mult = 1
+
 		# country_bpm_base_mandate_add = 70
 	}
 
@@ -765,30 +686,30 @@ law_wealth_voting = {
 		}
 	}
 
-	pop_support = {
-		value = 0
-
-		add = {
-			desc = "POP_LITERACY"
-			
-			if = {
-				limit = { 
-					NOT = { strata = upper }
-					owner = { 
-						NOR = {
-							has_law = law_type:law_census_voting
-							has_law = law_type:law_universal_suffrage
-							has_law = law_type:law_anarchy
-						}	
-					}
-				}
-				add = {
-					value = literacy_rate
-					divide = 2
-				}
-			}
-		}			
-	}
+#	pop_support = {
+#		value = 0
+#
+#		add = {
+#			desc = "POP_LITERACY"
+#			
+#			if = {
+#				limit = { 
+#					NOT = { strata = upper }
+#					owner = { 
+#						NOR = {
+#							has_law = law_type:law_census_voting
+#							has_law = law_type:law_universal_suffrage
+#							has_law = law_type:law_anarchy
+#						}	
+#					}
+#				}
+#				add = {
+#					value = literacy_rate
+#					divide = 2
+#				}
+#			}
+#		}			
+#	}
 
 	ai_enact_weight_modifier = { #Petitions
 		value = 0
@@ -842,6 +763,9 @@ law_census_voting = {
 		country_authority_add = 100
 		country_institution_suffrage_max_investment_add = 1
 		country_institution_cost_institution_suffrage_mult = -0.85
+		state_political_strength_from_wealth_mult = 0.75
+		state_pop_pol_str_add = -1
+
 		# country_bpm_base_mandate_add = 90
 	}
 
@@ -852,8 +776,9 @@ law_census_voting = {
 		country_voting_power_wealth_threshold_add = -5
 		country_voting_power_from_literacy_add = 6
 		country_authority_add = -10
-		state_radicals_from_sol_change_mult = -0.025
+		state_radicals_from_political_movements_mult = -0.025
 		country_rigidity_baseline_add = -5
+		country_bpm_labor_consciousness_target_mult = -0.02
 	}
 
 	on_activate = {
@@ -882,29 +807,29 @@ law_census_voting = {
 		}
 	}
 
-	pop_support = {
-		value = 0
-
-		add = {
-			desc = "POP_ANGRY_UNSTABLE"
-			
-			if = {
-				limit = { 
-					owner = { 
-						var:bpm_political_stability <= 33	
-						NOR = {
-							has_law = law_type:law_universal_suffrage
-							has_law = law_type:law_anarchy
-						}
-					}
-					NOT = { strata = upper }
-				}
-				add = {
-					value = pop_radical_fraction
-				}
-			}
-		}			
-	}
+#	pop_support = {
+#		value = 0
+#
+#		add = {
+#			desc = "POP_ANGRY_UNSTABLE"
+#			
+#			if = {
+#				limit = { 
+#					owner = { 
+#						var:bpm_political_stability <= 33	
+#						NOR = {
+#							has_law = law_type:law_universal_suffrage
+#							has_law = law_type:law_anarchy
+#						}
+#					}
+#					NOT = { strata = upper }
+#				}
+#				add = {
+#					value = pop_radical_fraction
+#				}
+#			}
+#		}			
+#	}
 
 	ai_enact_weight_modifier = { #Petitions
 		value = 0
@@ -958,6 +883,9 @@ law_universal_suffrage = {
 		country_authority_add = 100
 		country_institution_suffrage_max_investment_add = 1
 		country_institution_cost_institution_suffrage_mult = -0.85
+		state_political_strength_from_wealth_mult = 0.25
+		country_populist_movement_support_add = 0.05
+
 		# country_bpm_base_mandate_add = 100
 	}
 
@@ -968,8 +896,9 @@ law_universal_suffrage = {
 		country_voting_power_base_add = 6
 		country_voting_power_wealth_threshold_add = -6
 		country_authority_add = -20
-		state_radicals_from_sol_change_mult = -0.05
+		state_radicals_from_political_movements_mult = -0.05
 		country_rigidity_baseline_add = -5
+		country_bpm_labor_consciousness_target_mult = -0.05
 	}
 
 	on_activate = {
@@ -998,28 +927,28 @@ law_universal_suffrage = {
 		}
 	}
 
-	pop_support = {
-		value = 0
-
-		add = {
-			desc = "POP_ANGRY_UNSTABLE"
-			
-			if = {
-				limit = { 
-					owner = { 
-						NOT = {
-							has_law = law_type:law_anarchy
-						}
-						var:bpm_political_stability <= 33	
-					}
-					NOT = { strata = upper }
-				}
-				add = {
-					value = pop_radical_fraction
-				}
-			}
-		}					
-	}
+#	pop_support = {
+#		value = 0
+#
+#		add = {
+#			desc = "POP_ANGRY_UNSTABLE"
+#			
+#			if = {
+#				limit = { 
+#					owner = { 
+#						NOT = {
+#							has_law = law_type:law_anarchy
+#						}
+#						var:bpm_political_stability <= 33	
+#					}
+#					NOT = { strata = upper }
+#				}
+#				add = {
+#					value = pop_radical_fraction
+#				}
+#			}
+#		}					
+#	}
 
 	ai_enact_weight_modifier = { #Petitions
 		value = 0
@@ -1119,25 +1048,25 @@ law_anarchy = {
 		}
 	}
 
-	pop_support = {
-		value = 0
-
-		add = {
-			desc = "POP_ANGRY_UNSTABLE"
-			
-			if = {
-				limit = { 
-					owner = { 
-						var:bpm_political_stability <= 33	
-					}
-					NOT = { strata = upper }
-				}
-				add = {
-					value = pop_radical_fraction
-				}
-			}
-		}		
-	}
+#	pop_support = {
+#		value = 0
+#
+#		add = {
+#			desc = "POP_ANGRY_UNSTABLE"
+#			
+#			if = {
+#				limit = { 
+#					owner = { 
+#						var:bpm_political_stability <= 33	
+#					}
+#					NOT = { strata = upper }
+#				}
+#				add = {
+#					value = pop_radical_fraction
+#				}
+#			}
+#		}		
+#	}
 
 	ai_enact_weight_modifier = { #Petitions
 		value = 0
@@ -1193,9 +1122,9 @@ law_single_party_state = {
 		always = no
 	}
 	
-	pop_support = {
-		value = 0
-	}
+#	pop_support = {
+#		value = 0
+#	}
 
 	can_impose = { 
 		always = no


### PR DESCRIPTION
Removes duplicate wealth voting entry. Also adds in bugfixes made since the initial release.

Re-adds state pop political power, because without it you can have, say, landed voting where there's no votes because no one has political power to vote.